### PR TITLE
feat: use json prase and json stringfy to deep clone an initialState

### DIFF
--- a/packages/store/test/store.spec.ts
+++ b/packages/store/test/store.spec.ts
@@ -254,6 +254,28 @@ describe('#store', () => {
             });
         });
 
+        it('should clear state success after only change an animal name', () => {
+            const animals = createSomeAnimals();
+            const _animals = createSomeAnimals();
+            const foo = { id: 1, name: 'foo name', description: 'foo description' };
+            store = new ZoomStore({
+                animals: animals,
+                foo: foo
+            });
+            store.setState(state => {
+                const catIndex = state.animals.findIndex(animal => animal.name === 'cat')
+                state.animals[catIndex] = { name: 'cat', id: 100 }
+                state.animals = [...state.animals]
+                return state
+            });
+            expect(store.getState().animals.find(animal => animal.name === 'cat').id).toEqual(100);
+            store.clearState();
+            expect(store.getState()).toEqual({
+                animals: _animals,
+                foo: foo
+            });
+        })
+
         it('should get correct snapshot', () => {
             const animals = createSomeAnimals();
             const foo = { id: 1, name: 'foo name', description: 'foo description' };


### PR DESCRIPTION
借助JSON的序列化对初始state进行深克隆，避免在clearState时使用的stateCache因对象引用而与初始状态不同。
但需要注意的是，json标准中不支持NaN、undefined等内容，具体请参照[MDN](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)。

为避免undefined导致JSON序列化出现问题，在stringfy时将undefined同意替换为null。（相对于undefined，null的语义更适用于初始值）