### PR TITLE
feat: develop form directive

### DIFF
--- a/packages/store/form/form-store.ts
+++ b/packages/store/form/form-store.ts
@@ -1,11 +1,48 @@
 import { Injectable } from '@angular/core';
+import { FormControlStatus, ValidationErrors } from '@angular/forms';
 import { Store, setObjectValue } from '@tethys/store';
 
 export interface FormModelState<T> {
     model: T;
-    dirty: boolean;
-    status: string;
-    errors: {};
+    dirty: boolean | null;
+    // 字段类型和angular保持一致
+    status: FormControlStatus | null;
+    errors: ValidationErrors | null;
+}
+
+/**
+ * 使用该方法在store中构建一个表单对象
+ * @example
+ * ````
+ * class A extends Store<{ a: string, form: FormModelState<string> }>{
+ *  constructor(){
+ *      super({
+ *          a: 'str',
+ *          form: createFormModel('myForm')
+ *      })
+ *  }
+ * }
+ * ````
+ *
+ */
+export function createFormModel<T>(
+    model: T,
+    options: {
+        dirty: boolean | null,
+        status: FormControlStatus | null,
+        errors: ValidationErrors | null;
+    } = {
+        dirty: null,
+        status: null,
+        errors: null
+    }
+): FormModelState<T>{
+    return {
+        model,
+        dirty: options.dirty,
+        status: options.status,
+        errors: options.errors
+    }
 }
 
 @Injectable()

--- a/packages/store/form/form.directive.ts
+++ b/packages/store/form/form.directive.ts
@@ -1,46 +1,136 @@
-import { Directive, Input, OnInit, OnDestroy } from '@angular/core';
+import { Directive, Input, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { FormGroup, FormGroupDirective } from '@angular/forms';
 import { Store } from '@tethys/store';
+import { produce } from '@tethys/cdk/immutable';
 import { Observable, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map, take, takeUntil } from 'rxjs/operators';
 
 @Directive({ selector: '[thyStoreForm]' })
 export class StoreFormDirective implements OnInit, OnDestroy {
     @Input('thyStoreForm') store: Store;
 
-    @Input() thyStateKey: string;
+    @Input() thyStatePath: string;
 
-    debounce = 100;
+    @Input() thyClearDestroy = true
+
+    @Input() thyDynamic = false
+
+    /**
+     * 当表单控件的updateOn属性为change时，使用debounce值来提高性能，如果希望change后store同步反应变化，请将debounce设为-1
+     */
+    @Input()
+    set thyDebounce(debounce: string | number) {
+        this._debounce = Number(debounce);
+    }
+
+    get debounce(): number{
+        return this._debounce
+    }
+
+    private _debounce = 100;
 
     private updating = false;
 
+    private get path(){
+        return this.thyStatePath
+    }
+
     private destroy$ = new Subject<void>();
 
-    constructor(private formGroup: FormGroupDirective) {}
+    constructor(
+        private formGroup: FormGroupDirective,
+        private _cdr: ChangeDetectorRef
+    ) {}
 
     ngOnInit(): void {
+        // TODO 之后完善FormStore的时候，这里仍需要对表单状态相关操作的响应
+        // this.getFormReset$().pipe(
+        //         filter(payload => payload.path === this.path)
+        //     ).subscribe(payload => {
+        //         this.formGroup.reset(payload.value)
+        //         this.updateStateWithRawValue(true)
+        //         this._cdr.markForCheck();
+        //     })
+
+        // 如果是动态表单，意味着用户会根据一些获取到的数据初始化表单控件，此时，无法在store中提前确定表单model的内容，故需要指令初始化时，将组件内的表单内容同步到store中
+        if(this.thyDynamic) {
+            this.getStateStream(`${this.path}`)
+                .pipe(take(1))
+                .subscribe(() => {
+                    this.store.update(state => {
+                        let obj = produce(state).set(`${this.path}.model`, this.form.getRawValue())
+                        obj = produce(obj).set(`${this.path}.status`, this.form.status)
+                        obj = produce(obj).set(`${this.path}.dirty`, this.form.dirty)
+                        return obj
+                    })
+                });
+        }
+
+        this.getStateStream(`${this.path}.model`).subscribe(model => {
+            if(this.updating) {
+                return
+            }
+            this.form.patchValue(model)
+            this._cdr.markForCheck()
+        })
+        this.getStateStream(`${this.path}.dirty`).subscribe(dirty => {
+            if (this.form.dirty === dirty || typeof dirty !== 'boolean') {
+                return;
+              }
+              if (dirty) {
+                this.form.markAsDirty();
+              } else {
+                this.form.markAsPristine();
+              }
+              this._cdr.markForCheck();
+        })
+        // disabled状态源自于status，故不另设disabled属性，保持简洁
+        this.getStateStream(`${this.path}.status`).pipe(map(status => status === 'DISABLED')).subscribe(disabled => {
+            if (this.form.disabled === disabled || typeof disabled !== 'boolean') {
+                return;
+            }
+            if (disabled) {
+                this.form.disable();
+            } else {
+                this.form.enable();
+            }
+            this._cdr.markForCheck();
+        })
+
+        /**
+         * ngOnInit里的这几个部分有顺序要求，从store订阅数据并向formGroup同步的代码必须放置于订阅formGroup之前，从而保证初始化的时候可以将store中的数据准确初始化至formGroup。
+         * 如果将下方这个代码放到其他内容之前，则会导致store中dirty的丢失。
+         * 因为store中的form初始值会在指令init的时候set至formGroup，formGroup触发valueChanges方法，并在对valueChanges的订阅中将form同步到store，导致store中的dirty初始值被覆盖
+         */
         this.formGroup
             .valueChanges!.pipe(
                 distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
                 this.debounceChange()
             )
             .subscribe(() => {
-                this.updateStateWithRawValue(true);
+                this.updateStateWithRawValue();
             });
 
-        this.store.select((state) => {
-            return state[this.thyStateKey];
-        });
+        this.formGroup
+            .statusChanges!.pipe(distinctUntilChanged(), this.debounceChange())
+            .subscribe((status: string) => {
+                this.store.update(state => {
+                    return produce(state).set(`${this.path}.status`, status)
+                })
+            });
     }
 
-    updateStateWithRawValue(withFormStatus: boolean) {
+    // 只有当表单reset的时候，才会将formStatus与value一起同步到store中。其他情况，分别处理value与status的变化
+    updateStateWithRawValue(withFormStatus = false) {
         if (this.updating) return;
 
         const value = this.formGroup.control.getRawValue();
 
         let updateState = {
             model: value,
-            status: undefined
+            status: null,
+            dirty: this.formGroup.dirty,
+            errors: this.formGroup.errors
         };
         if (withFormStatus) {
             updateState.status = this.formGroup.status;
@@ -49,12 +139,11 @@ export class StoreFormDirective implements OnInit, OnDestroy {
         this.updating = true;
 
         this.store.update((state) => {
-            return {
-                [`${this.thyStateKey}`]: {
-                    ...state[this.thyStateKey],
-                    ...updateState
-                }
-            };
+            let obj = produce(state).set(`${this.path}.model`, updateState.model)
+            obj = produce(obj).set(`${this.path}.status`, updateState.status)
+            obj = produce(obj).set(`${this.path}.dirty`, updateState.dirty)
+            obj = produce(obj).set(`${this.path}.errors`, updateState.errors)
+            return obj
         });
         this.updating = false;
     }
@@ -62,6 +151,15 @@ export class StoreFormDirective implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.destroy$.next();
         this.destroy$.complete();
+        if (this.thyClearDestroy) {
+            this.store.update(state => {
+                let obj = produce(state).set(`${this.path}.model`, null)
+                obj = produce(obj).set(`${this.path}.status`, null)
+                obj = produce(obj).set(`${this.path}.dirty`, null)
+                obj = produce(obj).set(`${this.path}.errors`, null)
+                return obj
+            })
+          }
     }
 
     private debounceChange() {
@@ -76,7 +174,7 @@ export class StoreFormDirective implements OnInit, OnDestroy {
         return this.formGroup.form;
     }
 
-    // private getStateStream(path: string) {
-    //     return this.store.select(state => getValue(state, path)).pipe(takeUntil(this.destroy$));
-    // }
+    private getStateStream(path: string) {
+        return this.store.select(state => produce(state).get(path)).pipe(takeUntil(this.destroy$));
+    }
 }

--- a/packages/store/store.ts
+++ b/packages/store/store.ts
@@ -1,6 +1,6 @@
 import { Injectable, isDevMode, OnDestroy } from '@angular/core';
 import { isFunction, isNumber, isObject } from '@tethys/cdk/is';
-import { BehaviorSubject, from, Observable, Observer, Subscription } from 'rxjs';
+import { BehaviorSubject, from, Observable, Observer, Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
 import { Action } from './action';
 import { StoreMetaInfo } from './inner-types';

--- a/packages/store/test/form.spec.ts
+++ b/packages/store/test/form.spec.ts
@@ -1,0 +1,294 @@
+import { ChangeDetectionStrategy, Component, Injectable } from "@angular/core";
+import { FormBuilder, FormControlStatus, FormGroup, FormControl, ReactiveFormsModule, ValidationErrors, AbstractControl } from "@angular/forms";
+import { Store } from "../store";
+import { FormModelState, createFormModel } from "../form/form-store";
+import { Action } from '../action';
+import { TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { StoreFormDirective } from "../form";
+import { By } from "@angular/platform-browser";
+import { CommonModule } from "@angular/common";
+import { produce } from "@tethys/cdk";
+
+@Injectable()
+class TestStore extends Store<{ obj: { form: FormModelState<{ value: string|null }> } }>{
+  constructor(){
+    super({
+      obj: {
+        form: createFormModel({ value: 'test' }, {
+          dirty: true,
+          status: null,
+          errors: {}
+        })
+      }
+    })
+  }
+
+  @Action()
+  setFormValue(value: string | null):void{
+    this.update(state => {
+      let form = state.obj.form
+      form = {
+        ...form,
+        model: { value }
+      }
+      state.obj.form = form
+      return state
+    })
+  }
+
+  changeFormStatus(status: FormControlStatus | null):void{
+    this.update(state => {
+      let obj = produce(state).set('obj.form.status', status)
+      return obj
+    })
+  }
+}
+
+@Component({
+  selector: 'thy-test-form',
+  template: `
+    <form [formGroup]="form" [thyStoreForm]="store" thyStatePath="obj.form" thyDebounce="-1" [thyClearDestroy]="true">
+      <input type="text" formControlName="value">
+    </form>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+class TestFormPluginComponent{
+  public form: FormGroup
+  constructor(
+    public store: TestStore,
+    private fb: FormBuilder
+  ){
+    this.form = this.fb.group({
+      value: new FormControl()
+    })
+  }
+
+  setFormValue(value: string | null){
+    this.form.patchValue({ value })
+  }
+}
+
+@Component({
+  selector: 'thy-test-form-required',
+  template: `
+    <form [formGroup]="form" [thyStoreForm]="store" thyStatePath="obj.form" thyDebounce="-1" [thyClearDestroy]="true">
+      <input type="text" formControlName="value">
+    </form>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+class TestFormRequiredPluginComponent{
+  public form: FormGroup
+  constructor(
+    public store: TestStore,
+    private fb: FormBuilder
+  ){
+    this.form = this.fb.group({
+      value: this.fb.control(null, this.cantBeNull)
+    })
+  }
+
+  setFormValue(value: string | null){
+    this.form.patchValue({ value })
+  }
+
+  cantBeNull(control: AbstractControl<any, any>): ValidationErrors{
+    if(control.value === null) {
+      return {
+        'cantBeNull': true
+      }
+    }
+    return null
+  }
+}
+
+@Component({
+  selector: 'thy-test-debounce-form',
+  template: `
+    <form [formGroup]="form" [thyStoreForm]="store" thyStatePath="obj.form" [thyClearDestroy]="true">
+      <input type="text" formControlName="value">
+    </form>
+  `
+})
+class TestDebounceFormPluginComponent{
+  public form: FormGroup
+  constructor(
+    public store: TestStore,
+    private fb: FormBuilder
+  ){
+    this.form = this.fb.group({
+      value: new FormControl()
+    })
+  }
+
+  setFormValue(value: string | null){
+    this.form.patchValue({ value })
+  }
+}
+
+describe("form directive", () => {
+  it("should sync model and dirty from store to component when init", () => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestFormPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formFixture = TestBed.createComponent(TestFormPluginComponent)
+    formFixture.detectChanges()
+    const input = formFixture.debugElement.query(By.css("form input")).nativeElement;
+    expect(input.value).toBe("test")
+    expect(formFixture.componentInstance.form.dirty).toBe(true)
+  })
+
+  it("should get new value and 'dirty' status in component synchronal", () => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestFormPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formFixture = TestBed.createComponent(TestFormPluginComponent)
+    formFixture.detectChanges()
+    const input = formFixture.debugElement.query(By.css("form input")).nativeElement;
+    expect(formFixture.componentInstance.form.dirty).toBe(true)
+    store.update(state => {
+      let obj = produce(state).set("obj.form.model", { value: 'is not dirty' })
+      obj = produce(obj).set("obj.form.dirty", false)
+      return obj
+    })
+    expect(formFixture.componentInstance.form.dirty).toBe(false)
+    expect(input.value).toBe("is not dirty")
+  })
+
+  it("should get new value in store synchronal when ui change", () => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestFormPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formFixture = TestBed.createComponent(TestFormPluginComponent)
+    formFixture.detectChanges()
+    const input = formFixture.debugElement.query(By.css("form input")).nativeElement;
+    input.value = 'new input'
+    input.dispatchEvent(new KeyboardEvent('input'))
+    expect(store.snapshot.obj.form.model).toEqual({ value: 'new input' })
+  })
+
+  it("should react in dom and store when developer set formControl value in component", () => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestFormPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formFixture = TestBed.createComponent(TestFormPluginComponent)
+    formFixture.detectChanges()
+    const input = formFixture.debugElement.query(By.css("form input")).nativeElement;
+    formFixture.componentInstance.setFormValue('new form value')
+    expect(input.value).toBe("new form value")
+    expect(store.snapshot.obj.form.model).toEqual({ value: "new form value" })
+  })
+
+  it("should get new value in store asynchronous when ui change", fakeAsync(() => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestDebounceFormPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formDebounceFixture = TestBed.createComponent(TestDebounceFormPluginComponent)
+    formDebounceFixture.detectChanges()
+    const input = formDebounceFixture.debugElement.query(By.css("form input")).nativeElement;
+    input.value = 'new input'
+    input.dispatchEvent(new KeyboardEvent('input'))
+    expect(store.snapshot.obj.form.model).toEqual({ value: 'test' })
+    tick(100)
+    expect(store.snapshot.obj.form.model).toEqual({ value: 'new input' })
+  }))
+
+  it("should clear form in store when thyClearDestroy is true", () => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestFormPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formFixture = TestBed.createComponent(TestFormPluginComponent)
+    formFixture.detectChanges()
+    const input = formFixture.debugElement.query(By.css("form input")).nativeElement;
+    expect(input.value).toBe("test")
+    expect(formFixture.componentInstance.form.dirty).toBe(true)
+    formFixture.destroy()
+    expect(store.snapshot.obj.form).toEqual({
+      model: null,
+      errors: null,
+      dirty: null,
+      status: null
+    })
+  })
+
+  it("should be invalid when form model value is null", () => {
+    TestBed.resetTestingModule()
+    TestBed.configureTestingModule({
+      declarations: [
+        TestFormRequiredPluginComponent,
+        StoreFormDirective
+      ],
+      imports: [ CommonModule, ReactiveFormsModule ],
+      providers: [ TestStore ],
+    })
+    const store = TestBed.inject(TestStore)
+    const formFixture = TestBed.createComponent(TestFormRequiredPluginComponent)
+    formFixture.detectChanges()
+    store.setFormValue(null)
+    expect(store.snapshot.obj.form.status).toBe("INVALID")
+  })
+
+  // it("should be null when reset with null", () => {
+  //   TestBed.resetTestingModule()
+  //   TestBed.configureTestingModule({
+  //     declarations: [
+  //       TestFormPluginComponent,
+  //       StoreFormDirective
+  //     ],
+  //     imports: [ CommonModule, ReactiveFormsModule ],
+  //     providers: [ TestStore ],
+  //   })
+  //   const store = TestBed.inject(TestStore)
+  //   const formFixture = TestBed.createComponent(TestFormPluginComponent)
+  //   formFixture.detectChanges()
+  //   const input = formFixture.debugElement.query(By.css("form input")).nativeElement;
+  //   expect(input.value).toBe("test")
+  //   store.resetForm('obj.form',{ value: null })
+  //   expect(store.snapshot.obj.form.model).toEqual({ value: null })
+  //   expect(input.value).toBe("")
+  //   expect(formFixture.componentInstance.form.getRawValue()).toEqual({ value: null })
+  // })
+})


### PR DESCRIPTION
参考ngxs实现了form.directive。
目前directive支持对store和表单的双向绑定。支持复杂路径。支持在store中resetForm。
在store中构建form相关内容时，应使用提供的工具方法thyFormModel。